### PR TITLE
working on CI/CD

### DIFF
--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -151,7 +151,7 @@ class IonResource:
                 log_call(tmp_log, (TOOL_DEPENDENCIES['git'], 'submodule', 'update', '--init'))
             commit = check_output((TOOL_DEPENDENCIES['git'], 'rev-parse', '--short', 'HEAD')).strip()
             self.__identifier = self._name
-            if not show_revision:
+            if show_revision:
                 self.__identifier += '_' + commit.decode()
             self._build_dir = os.path.abspath(os.path.join(self.__output_root, 'build', self.__identifier))
             logs_dir = os.path.abspath(os.path.join(self.__output_root, 'build', 'logs'))
@@ -770,7 +770,7 @@ def ion_test_driver(arguments):
             implementations += parse_implementations(ION_IMPLEMENTATIONS, output_root)
         check_tool_dependencies(arguments)
         for implementation in implementations:
-            implementation.install(show_revision=(implementation.name == replace_impl))
+            implementation.install(show_revision=(implementation.name != replace_impl))
         ion_tests_source = arguments['--ion-tests']
         if not ion_tests_source:
             ion_tests_source = ION_TESTS_SOURCE

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -17,7 +17,7 @@
 Usage:
     ion_test_driver.py [--implementation <description>]... [--ion-tests <description>] [--test <type>]...
                        [--local-only] [--cmake <path>] [--git <path>] [--maven <path>] [--java <path>]
-                       [--output-dir <dir>] [--results-file <file>] [<test_file>]...
+                       [--output-dir <dir>] [--results-file <file>] [--replace-impl <description>] [<test_file>]...
     ion_test_driver.py (--list)
     ion_test_driver.py (-h | --help)
 
@@ -50,6 +50,10 @@ Options:
     -r, --results-file <file>           Path to the results output file. By default, this will be placed in a file named
                                         `ion-test-driver-results.ion` under the directory specified by the
                                         `--output-dir` option.
+
+    -R, --replace-impl <description>    Override one specific default ion-tests location by providing a description of
+                                        the form location,revision. Note that the implementation with the same name will
+                                        be replaced.
 
     -t, --test <type>                   Perform a particular test type or types, chosen from `good`, `bad`, `equivs`,
                                         `non-equivs`, and `all`. [default: all]
@@ -92,7 +96,8 @@ def check_tool_dependencies(args):
             # to call a tool-specific command to test the existence of the executable. This should be a command that
             # always returns zero.
             no_output = open(os.devnull, 'w')
-            check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
+            if name != 'java':
+                check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
         except:
             raise ValueError(name + " not found. Try specifying its location using --" + name + ".")
         finally:
@@ -746,6 +751,10 @@ def ion_test_driver(arguments):
                 print(impl_name)
     else:
         output_root = os.path.abspath(arguments['--output-dir'])
+        if arguments['--replace-impl']:
+            for index in range(len(ION_IMPLEMENTATIONS)):
+                if arguments['--replace-impl'].split(',')[0] == ION_IMPLEMENTATIONS[index].split(',')[0]:
+                    ION_IMPLEMENTATIONS[index] = arguments['--replace-impl']
         if not os.path.exists(output_root):
             os.makedirs(output_root)
         implementations = parse_implementations(arguments['--implementation'], output_root)

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -51,10 +51,10 @@ Options:
                                         `ion-test-driver-results.ion` under the directory specified by the
                                         `--output-dir` option.
 
-    -R, --replace-impl <description>    Override one specific default ion-tests location by providing a description of
+    -R, --replace-impl <description>    Override one specific default implementation by providing a description of
                                         the form location,revision. Note that the implementation showed in --list with
-                                        the same name will be replaced. It will show 'ion-java' as the name in the
-                                        result file rather than ion-java_revision_number.
+                                        the same name will be replaced. It will show 'implementation-name' as the name
+                                        in the result file rather than implementation-name_revision_number.
 
     -t, --test <type>                   Perform a particular test type or types, chosen from `good`, `bad`, `equivs`,
                                         `non-equivs`, and `all`. [default: all]

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -101,7 +101,7 @@ def check_tool_dependencies(args):
             # to call a tool-specific command to test the existence of the executable. This should be a command that
             # always returns zero.
             no_output = open(os.devnull, 'w')
-            if name == 'ion-java':
+            if name == 'java':
                 check_call([path, '-help'], stdout=no_output, shell=COMMAND_SHELL)
             else:
                 check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -101,8 +101,7 @@ def check_tool_dependencies(args):
             # to call a tool-specific command to test the existence of the executable. This should be a command that
             # always returns zero.
             no_output = open(os.devnull, 'w')
-            if name != 'java':
-                check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
+            check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
         except:
             raise ValueError(name + " not found. Try specifying its location using --" + name + ".")
         finally:

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -15,7 +15,6 @@
 """Cross-implementation test driver.
 
 Usage:
-    ion_test_driver.py (--compare-res <path>)...
     ion_test_driver.py [--implementation <description>]... [--ion-tests <description>] [--test <type>]...
                        [--local-only] [--cmake <path>] [--git <path>] [--java <path>] [--maven <path>]
                        [--output-dir <dir>] [--results-file <file>] [--replace-impl <description>] [<test_file>]...
@@ -23,9 +22,6 @@ Usage:
     ion_test_driver.py (-h | --help)
 
 Options:
-    -c, --compare-res <path> <path>     A specific mode comparing two result files by given paths. Raise an Error if
-                                        two files are different.
-
     --cmake <path>                      Path to the cmake executable.
 
     --git <path>                        Path to the git executable.
@@ -752,12 +748,6 @@ def parse_implementations(descriptions, output_root):
             for description in descriptions]
 
 
-def compare_files(files):
-    if len(files) != 2:
-        raise ValueError("Invalid file numbers. Need exactly two files to compare")
-    check_call(('diff', '-B', files[0], files[1]), shell=COMMAND_SHELL)
-
-
 def ion_test_driver(arguments):
     if arguments['--help']:
         print(__doc__)
@@ -765,8 +755,6 @@ def ion_test_driver(arguments):
         for impl_name in ION_BUILDS.keys():
             if impl_name != 'ion-tests':
                 print(impl_name)
-    elif arguments['--compare-res']:
-        compare_files(arguments['--compare-res'])
     else:
         output_root = os.path.abspath(arguments['--output-dir'])
         replace_impl = ""

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -101,10 +101,7 @@ def check_tool_dependencies(args):
             # to call a tool-specific command to test the existence of the executable. This should be a command that
             # always returns zero.
             no_output = open(os.devnull, 'w')
-            if name == 'java':
-                check_call([path, '-help'], stdout=no_output, shell=COMMAND_SHELL)
-            else:
-                check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
+            check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
         except:
             raise ValueError(name + " not found. Try specifying its location using --" + name + ".")
         finally:

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -101,7 +101,10 @@ def check_tool_dependencies(args):
             # to call a tool-specific command to test the existence of the executable. This should be a command that
             # always returns zero.
             no_output = open(os.devnull, 'w')
-            check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
+            if name == 'ion-java':
+                check_call([path, '-help'], stdout=no_output, shell=COMMAND_SHELL)
+            else:
+                check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
         except:
             raise ValueError(name + " not found. Try specifying its location using --" + name + ".")
         finally:

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -51,10 +51,10 @@ Options:
                                         `ion-test-driver-results.ion` under the directory specified by the
                                         `--output-dir` option.
 
-    -R, --replace-impl <description>    Override one specific default implementation by providing a description of
-                                        the form location,revision. Note that the implementation showed in --list with
-                                        the same name will be replaced. It will show 'implementation-name' as the name
-                                        in the result file rather than implementation-name_revision_number.
+    -R, --replace-impl <description>    Override a specific default implementation by providing a description of
+                                        the form name,location,revision. Note that the implementation showed in `--list`
+                                        with the same name will be replaced. It will show `implementation-name` in the
+                                        result file rather than `implementation-name_revision_number`.
 
     -t, --test <type>                   Perform a particular test type or types, chosen from `good`, `bad`, `equivs`,
                                         `non-equivs`, and `all`. [default: all]

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -15,7 +15,7 @@
 """Cross-implementation test driver.
 
 Usage:
-    ion_test_driver.py [--compare-res <path> <path>]
+    ion_test_driver.py (--compare-res <path>)...
     ion_test_driver.py [--implementation <description>]... [--ion-tests <description>] [--test <type>]...
                        [--local-only] [--cmake <path>] [--git <path>] [--java <path>] [--maven <path>]
                        [--output-dir <dir>] [--results-file <file>] [--replace-impl <description>] [<test_file>]...
@@ -23,8 +23,8 @@ Usage:
     ion_test_driver.py (-h | --help)
 
 Options:
-    -c --compare-res <path>             A specific mode comparing two result files. It skips revision, message and
-                                        location during the comparing.
+    -c, --compare-res <path> <path>     A specific mode comparing two result files by given paths. Raise an Error if
+                                        two files are different.
 
     --cmake <path>                      Path to the cmake executable.
 
@@ -56,8 +56,9 @@ Options:
                                         `--output-dir` option.
 
     -R, --replace-impl <description>    Override one specific default ion-tests location by providing a description of
-                                        the form location,revision. Note that the implementation with the same name will
-                                        be replaced.
+                                        the form location,revision. Note that the implementation showed in --list with
+                                        the same name will be replaced. It will show 'ion-java' as the name in the
+                                        result file rather than ion-java_revision_number.
 
     -t, --test <type>                   Perform a particular test type or types, chosen from `good`, `bad`, `equivs`,
                                         `non-equivs`, and `all`. [default: all]
@@ -752,6 +753,12 @@ def parse_implementations(descriptions, output_root):
             for description in descriptions]
 
 
+def compare_files(files):
+    if len(files) != 2:
+        raise ValueError("Invalid file numbers. Need exactly two files to compare")
+    check_call(('diff', '-B', files[0], files[1]), shell=COMMAND_SHELL)
+
+
 def ion_test_driver(arguments):
     if arguments['--help']:
         print(__doc__)
@@ -760,8 +767,7 @@ def ion_test_driver(arguments):
             if impl_name != 'ion-tests':
                 print(impl_name)
     elif arguments['--compare-res']:
-        # didn't implement yet
-        print(arguments['--compare-res'])
+        compare_files(arguments['--compare-res'])
     else:
         output_root = os.path.abspath(arguments['--output-dir'])
         replace_impl = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ py==1.4.31
 pytest==2.9.2
 pytest-runner==2.8
 six==1.10.0
-amazon.ion==0.2.0
+amazon.ion==0.6.0
 docopt==0.6.2


### PR DESCRIPTION
### Description
Added logic to make ion-test-driver runnable in CI/CD pipeline.
Currently, I tested in my local repository. Once everything is done, I'll squash the commits and push it to main repository.

### What I did
1. **Updated requirements.txt.**
 Set ion-python from 0.2 to 0.6 (0.2 will cause some issues for dump method)
2. **Added -R options to support replacing a default implementation to any desired commit.**
For example when we test ion-java, the default ion-java location is amzn/ion-java master branch. If we want to run the ion-test-driver with the new PR commit, we just need to add `-R ion-java,amzn_ion-java_URL,PR_commit_hash`(format is name,location,commit).
Note that when we use -R command, the revision will be ignored. Hence the name of the implementation will just be something like 'ion-java' rather than 'ion-java_02f3de'
 



### Test
Tested in https://github.com/cheqianh/ion-java/pull/20. <- this branch will be deleted later since it's just used for test.

